### PR TITLE
fix: update dead link to Keplr CosmJS documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ const stargateClient = await getSigningPryzmClient({
 To broadcast messages, you can create signers with a variety of options:
 
 - [cosmos-kit](https://github.com/cosmology-tech/cosmos-kit/tree/main/packages/react#signing-clients) (recommended)
-- [keplr](https://docs.keplr.app/api/cosmjs.html)
+- [keplr](https://docs.keplr.app/api/use-with/cosmjs)
 - [cosmjs](https://gist.github.com/webmaster128/8444d42a7eceeda2544c8a59fbd7e1d9)
 
 **Amino Signer**


### PR DESCRIPTION
Hi! I fixes a dead link in the `README.md` file. The old link pointed to a deprecated or non-existent page for the Keplr CosmJS documentation. It has been updated to the correct and current URL.
